### PR TITLE
Two fixes for goog-require

### DIFF
--- a/cljs-nashorn/src/cljs/repl/nashorn.clj
+++ b/cljs-nashorn/src/cljs/repl/nashorn.clj
@@ -38,7 +38,8 @@
         (binding [ana/*cljs-ns* 'cljs.user]
           (repl/load-stream repl-env cljs-path res))
         (if-let [res (io/resource js-path)]
-          (-eval (io/reader res) repl-env js-path 1)
+          (with-open [reader (io/reader res)]
+            (-eval reader repl-env js-path 1))
           (throw (Exception. (str "Cannot find " cljs-path " or "
                                   js-path " in classpath")))))
       (swap! (:loaded-libs repl-env) conj rule))))

--- a/cljs-nashorn/src/cljs/repl/nashorn.clj
+++ b/cljs-nashorn/src/cljs/repl/nashorn.clj
@@ -36,7 +36,7 @@
                               repl-env "<cljs repl>" 1))]
       (if-let [res (io/resource cljs-path)]
         (binding [ana/*cljs-ns* 'cljs.user]
-          (repl/load-stream repl-env res))
+          (repl/load-stream repl-env cljs-path res))
         (if-let [res (io/resource js-path)]
           (-eval (io/reader res) repl-env js-path 1)
           (throw (Exception. (str "Cannot find " cljs-path " or "


### PR DESCRIPTION
- update load-stream to new version of CLJS (3 parameters instead of two)
- always close reader
